### PR TITLE
[Feat] X키 UI 취소 기능 추가

### DIFF
--- a/Assets/LDH/LDH_Scripts/LDH_Managers/UIManager.cs
+++ b/Assets/LDH/LDH_Scripts/LDH_Managers/UIManager.cs
@@ -1,52 +1,73 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-//using Unity.VisualScripting;
 using UnityEngine;
+using static Define;
 
 public class UIManager : Singleton<UIManager>
 {
+	//========================================//
     //pop up : 1회성 알림 -> 종료시 삭제
     //linked up : 계층 구조 UI -> 종료시 비활성화
-    
-    
+    //========================================//
+
+    #region Variables
     //rootUI : ui object의 최상의 부모(컨테이너)
     private GameObject _rootUI;
     //PopUp 용 스택
-    [SerializeField] private Stack<UI_PopUp> _popUpStack = new Stack<UI_PopUp>();
+    private Stack<UI_PopUp> _popUpStack = new Stack<UI_PopUp>();
     private int _order = 10;
     
     //Linked 용 스택
     [SerializeField] private List<UI_Linked> _linkList = new List<UI_Linked>();
     
-    
+    //UI Root
+    public GameObject RootUI
+    {
+	    get
+	    {
+		    if (_rootUI == null)
+		    {
+			    _rootUI = GameObject.Find("UI_Root");
+			    if (_rootUI == null)
+			    {
+				    _rootUI = new GameObject("UI_Root");
+			    }
+		    }
+
+		    return _rootUI;
+	    }
+    }
     
     //ui가 열려있는지 여부
     public bool IsAnyUIOpen =>  _popUpStack.Count > 0 || _linkList.Count > 0;
     //ui가 열려있는지 여부에 따른 액션이벤트
     public event Action OnAllUIClosed;
     
+    
+    #endregion
+
+
+    #region EventFunction
+    
     private void OnDestroy()
     {
 	    OnAllUIClosed = null;
     }
 
-    public GameObject RootUI
+    private void Update()
     {
-        get
-        {
-            if (_rootUI == null)
-            {
-                _rootUI = GameObject.Find("UI_Root");
-                if (_rootUI == null)
-                {
-                    _rootUI = new GameObject("UI_Root");
-                }
-            }
-
-            return _rootUI;
-        }
+	    if(!IsAnyUIOpen) return;
+	    if (Input.GetKeyDown(KeyCode.Z))
+	    {
+		    HandleUIInput(UIInputType.Select);
+	    }
+	    else if (Input.GetKeyDown(KeyCode.X))
+		    HandleUIInput(UIInputType.Cancel);
     }
+
+    #endregion
+    
     
     //캔버스 sorting order 셋팅
     public void SetCanvas(GameObject uiGameObject, bool isPopup = false)
@@ -68,14 +89,21 @@ public class UIManager : Singleton<UIManager>
     
     
     //z키 선택 알림
-    public void OnUISelect()
+    public void HandleUIInput(UIInputType inputType)
     {
 	    // 팝업 확인을 먼저한다.
 	    if (_popUpStack.Count > 0)
 	    {
 		    UI_PopUp topPopUp = _popUpStack.Peek();
-		    IUISelectable selectable = topPopUp.GetComponent<IUISelectable>();
-		    selectable?.OnSelect();
+		    switch (inputType)
+		    {
+			    case UIInputType.Select:
+				    (topPopUp as IUISelectable)?.OnSelect();
+				    break;
+			    case UIInputType.Cancel:
+				    (topPopUp as ICancelable)?.OnCancle();
+				    break;
+		    }
 		    return;
 	    }
 
@@ -83,12 +111,21 @@ public class UIManager : Singleton<UIManager>
 	    if (_linkList.Count > 0)
 	    {
 		    UI_Linked topLinked = _linkList[_linkList.Count - 1];
-		    IUISelectable selectable = topLinked.GetComponent<IUISelectable>();
-		    selectable?.OnSelect();
+		    switch (inputType)
+		    {
+			    case UIInputType.Select:
+				    (topLinked as IUISelectable)?.OnSelect();
+				    break;
+			    case UIInputType.Cancel:
+				    (topLinked as ICancelable)?.OnCancle();
+				    break;
+		    }
 		    return;
 	    }
 	    // 둘 다 없으면 무시
     }
+    
+    
     
 
     #region 팝업 UI

--- a/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/ICancelable.cs
+++ b/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/ICancelable.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+
+public interface ICancelable
+{
+	public void OnCancle();
+}

--- a/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/ICancelable.cs.meta
+++ b/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/ICancelable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dc69bc53ebbe4f0c8fba10848d10cc5a
+timeCreated: 1745983411

--- a/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Linked_Scripts/UI_Linked.cs
+++ b/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Linked_Scripts/UI_Linked.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class UI_Linked : MonoBehaviour
+public class UI_Linked : MonoBehaviour, IUISelectable, ICancelable
 {
     private void Start()
     {
@@ -22,5 +22,20 @@ public class UI_Linked : MonoBehaviour
     {
         gameObject.SetActive(false);
     }
-    
+
+    public virtual void OnCancle()
+    {
+	   CloseSelf();
+    }
+
+
+    protected void CloseSelf()
+    {
+	    Manager.UI.UndoLinkedUI();
+    }
+
+    //상속받은 쪽에서 구현하라고 처리
+    public virtual void OnSelect()
+    {
+    }
 }

--- a/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Linked_Scripts/UI_Menu.cs
+++ b/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Linked_Scripts/UI_Menu.cs
@@ -5,7 +5,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.Serialization;
 
-public class UI_Menu : UI_Linked, IUISelectable
+public class UI_Menu : UI_Linked
 {
     private static int _curIdx = 0;
     private int _preIdx = 0;
@@ -49,10 +49,6 @@ public class UI_Menu : UI_Linked, IUISelectable
         else if (Input.GetKeyDown(KeyCode.DownArrow))
         {
            MoveIdx(1);
-        }
-        else if (Input.GetKeyDown(KeyCode.Return)|| Input.GetKeyDown(KeyCode.KeypadEnter))
-        {
-            CloseSelf();
         }
     }
 
@@ -106,13 +102,8 @@ public class UI_Menu : UI_Linked, IUISelectable
 		    activeMenuButton.SetArrowActive(false);
 	    }
     }
-
-    void CloseSelf()
-    {
-        Manager.UI.UndoLinkedUI();
-    }
-
-    public void OnSelect()
+    
+    public override void OnSelect()
     {
 	    if (_curIdx == _activeMenuButtons.Count - 1)
 	    {
@@ -125,6 +116,7 @@ public class UI_Menu : UI_Linked, IUISelectable
 	    UI_MenuButton selectedButton = _activeMenuButtons[_curIdx];
 	    selectedButton.OpenMenu();
 	    
-	    
     }
+    
+    
 }

--- a/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Linked_Scripts/UI_PlayerCard.cs
+++ b/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Linked_Scripts/UI_PlayerCard.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 
-public class UI_PlayerCard : UI_Linked, IUISelectable
+public class UI_PlayerCard : UI_Linked
 {
 	[SerializeField] private GameObject[] infoPanels;
 	[SerializeField] private int curIdx;
@@ -50,20 +50,7 @@ public class UI_PlayerCard : UI_Linked, IUISelectable
 	    }
     }
 
-    public void OnSelect()
-    {
-	    //Status Panel에서 선택 입력 시, Badge Panel로 넘어감
-	    if (curIdx == 0)
-	    {
-		    curIdx = 1;
-		    UpdateInfoPanels();
-
-	    }
-
-	    //Badge Panel에서 선택 입력 시, 메뉴 종료됨
-	    else
-	    {
-		    Manager.UI.UndoLinkedUI();
-	    }
-    }
+    
+    //해당 UI는 선택 항목 처리가 필요 없는 화면이므로 OnSelect()는 오버라이드하지 않음
+    // OnCancle()은 UI_Linked의 기본 닫기 로직(CloseSelf)을 그대로 사용
 }

--- a/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_PopUP_Scripts/UI_PopUp.cs
+++ b/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_PopUP_Scripts/UI_PopUp.cs
@@ -3,16 +3,8 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class UI_PopUp : MonoBehaviour
+public class UI_PopUp : MonoBehaviour, IUISelectable, ICancelable
 {
-    private void Update()
-    {
-        if (Input.GetKeyDown(KeyCode.KeypadEnter))
-        {
-            ClosePopupUI();
-        }
-    }
-
     private void Start()
     {
         Init();
@@ -28,4 +20,15 @@ public virtual void ClosePopupUI()
     {
         Manager.UI.ClosePopupUI(this);
     }
+
+    public virtual void OnSelect()
+    {
+	    //일단 아무 기능 없이 둠
+	    //추후 구현 예정
+    }
+    public virtual void OnCancle()
+    {
+	    ClosePopupUI();
+    }
+    
 }

--- a/Assets/SJH/Define.cs
+++ b/Assets/SJH/Define.cs
@@ -51,4 +51,15 @@ public class Define
 		Dark,       // 악
 		Steel,      // 강철
 	}
+
+
+	#region UI
+	public enum UIInputType
+	{
+		Select,
+		Cancel,
+	}
+	
+
+	#endregion
 }

--- a/Assets/SJH/Player.cs
+++ b/Assets/SJH/Player.cs
@@ -234,7 +234,6 @@ public class Player : MonoBehaviour
 						// UI
 						break;
 					case PlayerState.Menu:
-						Manager.UI.OnUISelect();
 						break;
 					case PlayerState.Dialog:
 						// 대화


### PR DESCRIPTION
# 📌 Pull Request
## 🔗 관련 이슈
<!--
❗ 상황에 따라 아래 중 하나로 작성하세요:
- PR 머지 시 이슈를 자동으로 닫으려면: resolves: #45
- 단순히 연동만 하고 싶다면: related to: #45
-->

resolves: #44 

---

## ✨ 작업 내용
- UI 입력 타입을 enum으로 구분해서 선택/취소 모두 처리 가능하게 수정
- ICancelable 인터페이스 추가하고, UI_Linked와 PopUp에서 함께 상속하도록 변경
- UIManager에서 X키 입력을 직접 감지해 HandleUIInput에서 취소 처리
- 플레이어에서 하던 입력 처리는 제거 (플레이어가 없는 씬에서도 UI 작동하도록)



## 🎥 스크린샷 / 영상 (선택)
<!--드래그 앤 드롭으로 GitHub에 업로드 가능-->

---

## 💬 리뷰 요청사항
- 없음

---

## ✅ PR 체크리스트
- [x] 이슈 번호에 `resolves:` 또는 `related to:`를 정확히 작성했는가?
- [x] 불필요한 로그/주석/테스트 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작을 확인했는가?

---

## 📝 기타 참고사항 (선택)


