### PR TITLE
[Feat] 트레이너 데이터 추가, 스킬의 PP를 담는 구조체 추가

### DIFF
--- a/Assets/HCW/HCW_Scripts/BattleManager.cs
+++ b/Assets/HCW/HCW_Scripts/BattleManager.cs
@@ -308,6 +308,7 @@ public class BattleManager : MonoBehaviour
 						// 상태이상체크
 						if (act.Attacker.CanActionCheck())
 						{
+							// TODO : PP 체크
 							ExecuteAction(act);
 						}
 						isAction = true;
@@ -323,6 +324,7 @@ public class BattleManager : MonoBehaviour
 				case "Pokemon":
 					yield return StartCoroutine(PokemonSwitch());
 					{
+						// TODO : 상대 포켓몬의 PP 체크
 						ExecuteAction(new BattleAction(enemyPokemon, playerPokemon, enemySelectedSkill));
 
 						hud.SetPlayerHUD(playerPokemon);
@@ -427,8 +429,6 @@ public class BattleManager : MonoBehaviour
 	// 행동 선택 후 행동 처리
 	private void ExecuteAction(BattleAction action)
 	{
-		//Debug.Log($"{action.Attacker.pokeName} 사용 {action.Skill}");
-		//Attack(action.Attacker, action.Target, action.Skill);
 		var skill = Manager.Data.SkillSData.GetSkillDataByName(action.Skill);
 		skill.UseSkill(action.Attacker, action.Target, skill);
 	}

--- a/Assets/JHT/JHT_Scripts/SkillS.cs
+++ b/Assets/JHT/JHT_Scripts/SkillS.cs
@@ -12,7 +12,6 @@ public abstract class SkillS
 	public SkillType skillType;
 	public bool isMyStat;	// isMyStat?
 
-
 	public PokeType type; //포켓몬 타입이랑 기술 타입이랑 동일한 타입 사용해서 추가함(이도현)
 	public int curPP;	// pp에서 curPP와 maxPP로 분류 (손재훈)
 	public int maxPP;
@@ -20,8 +19,6 @@ public abstract class SkillS
 	public bool isHM; //비전머신 기술인지의 여부
 	public GameObject Physicsparticle;
 	public GameObject specialParticle;
-	
-
 
 	public SkillS(string _name, string _description, float _damage, SkillType _skillType,bool _isMyStat, PokeType _type, int _pp, float _accuracy, bool _isHm=false)
 	{
@@ -38,6 +35,4 @@ public abstract class SkillS
 	}
 
 	public abstract void UseSkill(Pokémon attacker, Pokémon defender, SkillS skill);
-
-	
 }

--- a/Assets/Prefabs/Trainer/GymLeader.prefab
+++ b/Assets/Prefabs/Trainer/GymLeader.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 1309219344706487297}
   - component: {fileID: 2797136849111708168}
   - component: {fileID: 4599934236008028391}
+  - component: {fileID: 2789888237553223355}
   m_Layer: 0
   m_Name: GymLeader
   m_TagString: NPC
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &2789888237553223355
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5664335217167810056}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 14
+  isFight: 0

--- a/Assets/Prefabs/Trainer/GymTrainer1.prefab
+++ b/Assets/Prefabs/Trainer/GymTrainer1.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 6935889747434955856}
   - component: {fileID: 4956606334184538711}
   - component: {fileID: 5330637258307192796}
+  - component: {fileID: -7712151069590217063}
   m_Layer: 0
   m_Name: GymTrainer1
   m_TagString: NPC
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &-7712151069590217063
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6333433098990245224}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 12
+  isFight: 0

--- a/Assets/Prefabs/Trainer/GymTrainer2.prefab
+++ b/Assets/Prefabs/Trainer/GymTrainer2.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 1731209807596438359}
   - component: {fileID: 8281601635632941560}
   - component: {fileID: 7236899142958983500}
+  - component: {fileID: -3960426084032112304}
   m_Layer: 0
   m_Name: GymTrainer2
   m_TagString: NPC
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &-3960426084032112304
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 402885664583249572}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 13
+  isFight: 0

--- a/Assets/Prefabs/Trainer/Trainer1.prefab
+++ b/Assets/Prefabs/Trainer/Trainer1.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 8436671094806815740}
   - component: {fileID: 3988801550068155020}
   - component: {fileID: 1333866571956011771}
+  - component: {fileID: -8556502551642484696}
   m_Layer: 0
   m_Name: Trainer1
   m_TagString: NPC
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &-8556502551642484696
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 855129069404770790}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 1
+  isFight: 0

--- a/Assets/Prefabs/Trainer/Trainer10.prefab
+++ b/Assets/Prefabs/Trainer/Trainer10.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 175516605476323804}
   - component: {fileID: 3804597765269580284}
   - component: {fileID: 8559517133341309919}
+  - component: {fileID: 65254815603143474}
   m_Layer: 0
   m_Name: Trainer10
   m_TagString: NPC
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &65254815603143474
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4397215102057081214}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 10
+  isFight: 0

--- a/Assets/Prefabs/Trainer/Trainer11.prefab
+++ b/Assets/Prefabs/Trainer/Trainer11.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 2759956378129593992}
   - component: {fileID: 6401262107919075143}
   - component: {fileID: 325230231366765954}
+  - component: {fileID: -7952704492104462902}
   m_Layer: 0
   m_Name: Trainer11
   m_TagString: NPC
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &-7952704492104462902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9010436730583564106}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 11
+  isFight: 0

--- a/Assets/Prefabs/Trainer/Trainer2.prefab
+++ b/Assets/Prefabs/Trainer/Trainer2.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 5874841706809598956}
   - component: {fileID: 2458323870094556752}
   - component: {fileID: 1709525994560299917}
+  - component: {fileID: -5680968356352194749}
   m_Layer: 0
   m_Name: Trainer2
   m_TagString: NPC
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &-5680968356352194749
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3381998677427486532}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 2
+  isFight: 0

--- a/Assets/Prefabs/Trainer/Trainer3.prefab
+++ b/Assets/Prefabs/Trainer/Trainer3.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 896225480530788079}
   - component: {fileID: 9141276825338937689}
   - component: {fileID: 245483977447961444}
+  - component: {fileID: -8884420118652607915}
   m_Layer: 0
   m_Name: Trainer3
   m_TagString: NPC
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &-8884420118652607915
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7831188307972461558}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 3
+  isFight: 0

--- a/Assets/Prefabs/Trainer/Trainer4.prefab
+++ b/Assets/Prefabs/Trainer/Trainer4.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 3126983124212425677}
   - component: {fileID: 2388375601335546217}
   - component: {fileID: 720610472425462062}
+  - component: {fileID: 8046480950115945477}
   m_Layer: 0
   m_Name: Trainer4
   m_TagString: NPC
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &8046480950115945477
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3351200124196414709}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 4
+  isFight: 0

--- a/Assets/Prefabs/Trainer/Trainer5.prefab
+++ b/Assets/Prefabs/Trainer/Trainer5.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &2102706370458984131
+--- !u!1 &4894863921100760156
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,9 +8,10 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5596190004431903596}
-  - component: {fileID: 5909523847874255524}
-  - component: {fileID: 3521416209062146606}
+  - component: {fileID: 2237673232042557750}
+  - component: {fileID: 6122627708551371632}
+  - component: {fileID: 5595776792283241578}
+  - component: {fileID: -5647680296618162829}
   m_Layer: 0
   m_Name: Trainer5
   m_TagString: NPC
@@ -18,28 +19,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5596190004431903596
+--- !u!4 &2237673232042557750
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2102706370458984131}
+  m_GameObject: {fileID: 4894863921100760156}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 8, y: 2, z: 0}
+  m_LocalPosition: {x: -16, y: 8, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &5909523847874255524
+--- !u!212 &6122627708551371632
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2102706370458984131}
+  m_GameObject: {fileID: 4894863921100760156}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -74,7 +75,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
-  m_Sprite: {fileID: 1392333050, guid: ae89d5c61429b004c81c30d2d48e1ddb, type: 3}
+  m_Sprite: {fileID: 1367313086, guid: ae89d5c61429b004c81c30d2d48e1ddb, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -85,13 +86,13 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!61 &3521416209062146606
+--- !u!61 &5595776792283241578
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2102706370458984131}
+  m_GameObject: {fileID: 4894863921100760156}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &-5647680296618162829
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4894863921100760156}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 5
+  isFight: 0

--- a/Assets/Prefabs/Trainer/Trainer6.prefab
+++ b/Assets/Prefabs/Trainer/Trainer6.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &4894863921100760156
+--- !u!1 &2102706370458984131
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,9 +8,10 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2237673232042557750}
-  - component: {fileID: 6122627708551371632}
-  - component: {fileID: 5595776792283241578}
+  - component: {fileID: 5596190004431903596}
+  - component: {fileID: 5909523847874255524}
+  - component: {fileID: 3521416209062146606}
+  - component: {fileID: 8761957139605123246}
   m_Layer: 0
   m_Name: Trainer6
   m_TagString: NPC
@@ -18,28 +19,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2237673232042557750
+--- !u!4 &5596190004431903596
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4894863921100760156}
+  m_GameObject: {fileID: 2102706370458984131}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -16, y: 8, z: 0}
+  m_LocalPosition: {x: 8, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &6122627708551371632
+--- !u!212 &5909523847874255524
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4894863921100760156}
+  m_GameObject: {fileID: 2102706370458984131}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -74,7 +75,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
-  m_Sprite: {fileID: 1367313086, guid: ae89d5c61429b004c81c30d2d48e1ddb, type: 3}
+  m_Sprite: {fileID: 1392333050, guid: ae89d5c61429b004c81c30d2d48e1ddb, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -85,13 +86,13 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!61 &5595776792283241578
+--- !u!61 &3521416209062146606
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4894863921100760156}
+  m_GameObject: {fileID: 2102706370458984131}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &8761957139605123246
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2102706370458984131}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 6
+  isFight: 0

--- a/Assets/Prefabs/Trainer/Trainer7.prefab
+++ b/Assets/Prefabs/Trainer/Trainer7.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 1954861082422017115}
   - component: {fileID: 7038285746808618387}
   - component: {fileID: 3851943237673874982}
+  - component: {fileID: 4847343044396479590}
   m_Layer: 0
   m_Name: Trainer7
   m_TagString: NPC
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &4847343044396479590
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5280291071405998094}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 7
+  isFight: 0

--- a/Assets/Prefabs/Trainer/Trainer8.prefab
+++ b/Assets/Prefabs/Trainer/Trainer8.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 4359646485064869161}
   - component: {fileID: 1733369598964348892}
   - component: {fileID: 5915683107075798582}
+  - component: {fileID: -3753142079596768854}
   m_Layer: 0
   m_Name: Trainer8
   m_TagString: NPC
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &-3753142079596768854
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7573142213560648051}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 8
+  isFight: 0

--- a/Assets/Prefabs/Trainer/Trainer9.prefab
+++ b/Assets/Prefabs/Trainer/Trainer9.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 859845575210519335}
   - component: {fileID: 1973383687751446169}
   - component: {fileID: 5525135404996171681}
+  - component: {fileID: -5706954716567388785}
   m_Layer: 0
   m_Name: Trainer9
   m_TagString: NPC
@@ -130,3 +131,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &-5706954716567388785
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8911250340496833189}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed59e50fca4f38e44a5f1ebdc10ede59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trainerId: 9
+  isFight: 0

--- a/Assets/SJH/EventManager.cs
+++ b/Assets/SJH/EventManager.cs
@@ -20,42 +20,183 @@ public class EventManager : Singleton<EventManager>
 		// 이벤트매니저에서 필드의 트레이너들 관리
 		trainerData = new()
 		{
+			// Route 30
 			[1] = new TrainerData()
 			{
 				TrainerId = 1,
-				Name = "재훈",
+				Name = "반바지 꼬마 오성",
 				IsFight = TrainerIsFight(1),
-				Money = 50,
+				Money = 64,
 				TrainerPartyData = new List<TrainerPokemon>()
 				{
 					new TrainerPokemon() { PokeName = "꼬렛", PokeLevel = 4 },
 				}
 			},
-
 			[2] = new TrainerData()
 			{
 				TrainerId = 2,
-				Name = "훈재",
+				Name = "반바지 꼬마 강철",
 				IsFight = TrainerIsFight(2),
-				Money = 100,
+				Money = 64,
 				TrainerPartyData = new List<TrainerPokemon>()
 				{
+					new TrainerPokemon() { PokeName = "구구", PokeLevel = 2 },
 					new TrainerPokemon() { PokeName = "꼬렛", PokeLevel = 4 },
-					new TrainerPokemon() { PokeName = "구구", PokeLevel = 4 },
 				}
 			},
-
 			[3] = new TrainerData()
 			{
 				TrainerId = 3,
-				Name = "훈재훈",
+				Name = "곤충채집소년 미키",
 				IsFight = TrainerIsFight(3),
-				Money = 500,
+				Money = 48,
 				TrainerPartyData = new List<TrainerPokemon>()
 				{
-					new TrainerPokemon() { PokeName = "뿔충이", PokeLevel = 4 },
-					new TrainerPokemon() { PokeName = "캐터피", PokeLevel = 4 },
-					new TrainerPokemon() { PokeName = "단데기", PokeLevel = 4 },
+					new TrainerPokemon() { PokeName = "캐터피", PokeLevel = 3 },
+					new TrainerPokemon() { PokeName = "캐터피", PokeLevel = 3 },
+				}
+			},
+
+			// Route 31
+			[4] = new TrainerData()
+			{
+				TrainerId = 4,
+				Name = "곤충채집소년 광일",
+				IsFight = TrainerIsFight(4),
+				Money = 32,
+				TrainerPartyData = new List<TrainerPokemon>()
+				{
+					new TrainerPokemon() { PokeName = "캐터피", PokeLevel = 2 },
+					new TrainerPokemon() { PokeName = "캐터피", PokeLevel = 2 },
+					new TrainerPokemon() { PokeName = "뿔충이", PokeLevel = 3 },
+					new TrainerPokemon() { PokeName = "캐터피", PokeLevel = 2 },
+				}
+			},
+
+			// Sprout Tower
+			// 1F
+			[5] = new TrainerData()
+			{
+				TrainerId = 5,
+				Name = "중 진연",
+				IsFight = TrainerIsFight(5),
+				Money = 96,
+				TrainerPartyData = new List<TrainerPokemon>()
+				{
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 3 },
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 3 },
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 3 },
+				}
+			},
+			// 2F
+			[6] = new TrainerData()
+			{
+				TrainerId = 6,
+				Name = "중 묵연",
+				IsFight = TrainerIsFight(6),
+				Money = 96,
+				TrainerPartyData = new List<TrainerPokemon>()
+				{
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 3 },
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 3 },
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 3 },
+				}
+			},
+			[7] = new TrainerData()
+			{
+				TrainerId = 7,
+				Name = "중 영창",
+				IsFight = TrainerIsFight(7),
+				Money = 96,
+				TrainerPartyData = new List<TrainerPokemon>()
+				{
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 3 },
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 3 },
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 3 },
+				}
+			},
+			// 3F
+			[8] = new TrainerData()
+			{
+				TrainerId = 8,
+				Name = "중 상연",
+				IsFight = TrainerIsFight(8),
+				Money = 192,
+				TrainerPartyData = new List<TrainerPokemon>()
+				{
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 6 },
+				}
+			},
+			[9] = new TrainerData()
+			{
+				TrainerId = 9,
+				Name = "중 가연",
+				IsFight = TrainerIsFight(9),
+				Money = 192,
+				TrainerPartyData = new List<TrainerPokemon>()
+				{
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 6 },
+				}
+			},
+			[10] = new TrainerData()
+			{
+				TrainerId = 10,
+				Name = "중 명연",
+				IsFight = TrainerIsFight(10),
+				Money = 224,
+				TrainerPartyData = new List<TrainerPokemon>()
+				{
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 7 },
+					new TrainerPokemon() { PokeName = "부우부", PokeLevel = 7 },
+				}
+			},
+			[11] = new TrainerData()
+			{
+				TrainerId = 11,
+				Name = "중 청성",
+				IsFight = TrainerIsFight(11),
+				Money = 320,
+				TrainerPartyData = new List<TrainerPokemon>()
+				{
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 7 },
+					new TrainerPokemon() { PokeName = "부우부", PokeLevel = 10 },
+					new TrainerPokemon() { PokeName = "모다피", PokeLevel = 7 },
+				}
+			},
+			// Violet City GYM
+			[12] = new TrainerData()
+			{
+				TrainerId = 12,
+				Name = "새조련사 소룡",
+				IsFight = TrainerIsFight(12),
+				Money = 216,
+				TrainerPartyData = new List<TrainerPokemon>()
+				{
+					new TrainerPokemon() { PokeName = "깨비참", PokeLevel = 9 },
+				}
+			},
+			[13] = new TrainerData()
+			{
+				TrainerId = 13,
+				Name = "새조련사 날개",
+				IsFight = TrainerIsFight(13),
+				Money = 168,
+				TrainerPartyData = new List<TrainerPokemon>()
+				{
+					new TrainerPokemon() { PokeName = "구구", PokeLevel = 7 },
+					new TrainerPokemon() { PokeName = "구구", PokeLevel = 7 },
+				}
+			},
+			[14] = new TrainerData()
+			{
+				TrainerId = 14,
+				Name = "체육관 관장 비상",
+				IsFight = TrainerIsFight(14),
+				Money = 900,
+				TrainerPartyData = new List<TrainerPokemon>()
+				{
+					new TrainerPokemon() { PokeName = "구구", PokeLevel = 7 },
+					new TrainerPokemon() { PokeName = "피죤", PokeLevel = 9 },
 				}
 			},
 		};

--- a/Assets/SJH/PokeTest/PokemonManager.cs
+++ b/Assets/SJH/PokeTest/PokemonManager.cs
@@ -37,6 +37,8 @@ public class PokemonManager : Singleton<PokemonManager>
 		party[1].condition = StatusCondition.Poison;
 		// AddPokemon(33, 10);
 
+		AddPokemon("블레이범", 50);
+
 	}
 
 	public void AddPokemon(string pokeName, int level)

--- a/Assets/SJH/PokeTest/Pokémon.cs
+++ b/Assets/SJH/PokeTest/Pokémon.cs
@@ -206,6 +206,7 @@ public class Pokémon : MonoBehaviour
 		{
 			foreach (int skillLevel in data.SkillDic.Keys)
 			{
+				// 포켓몬 레벨 이하면 추가
 				if (skillLevel <= level)
 				{
 					string skill = data.SkillDic[skillLevel];
@@ -250,6 +251,15 @@ public class Pokémon : MonoBehaviour
 		else
 		{
 			skills = allSkills;
+		}
+
+		// TODO : allSkills 의 List<string> 를 List<SkillData> 로 바꾸기
+		skillDatas = new();
+		foreach (string skillName in skills)
+		{
+			SkillS skills = Manager.Data.SkillSData.GetSkillDataByName(skillName);
+			SkillData skillData = new SkillData(skills.name, skills.maxPP, skills.maxPP);
+			skillDatas.Add(skillData);
 		}
 	}
 
@@ -699,8 +709,6 @@ public class Pokémon : MonoBehaviour
 				break;
 		}
 	AfterAtack:
-		// PP감소
-		attackSkill.curPP--;
 		// 마지막에 사용한 스킬 저장
 		attacker.prevSkillName = attackSkill.name;
 	}
@@ -1480,5 +1488,29 @@ public class Pokémon : MonoBehaviour
 		isForesight = false;
 		// 원한, 따라하기
 		prevSkillName = null;
-}
+	}
+
+	public bool SkillPPCheck(string skillName)
+	{
+		for (int i = 0; i < skillDatas.Count; i++)
+		{
+			if (skillDatas[i].Name == skillName)
+			{
+				var data = skillDatas[i];
+				
+				// PP 체크
+				if (data.CurPP <= 0)
+					return false;
+
+				// PP 감소
+				data.DecreasePP();
+				// 재할당
+				skillDatas[i] = data;
+
+				return true;
+			}
+		}
+		Debug.Log($"{skillName} 은/는 없는 스킬 입니다.");
+		return false;
+	}
 }

--- a/Assets/SJH/PokeTest/Pokémon.cs
+++ b/Assets/SJH/PokeTest/Pokémon.cs
@@ -49,6 +49,9 @@ public class Pokémon : MonoBehaviour
 	[Tooltip("배틀중일 때 스택 0 ~ 6")]
 	public PokemonBattleStat pokemonBattleStack;
 
+	[Tooltip("스킬 PP 관리")]
+	public List<SkillData> skillDatas = new();
+
 	#region 포켓몬 효과 관리 변수
 
 	[Tooltip("분노 관리용")]

--- a/Assets/SJH/SJH_NPC.cs
+++ b/Assets/SJH/SJH_NPC.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SJH_NPC : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/SJH/SJH_NPC.cs.meta
+++ b/Assets/SJH/SJH_NPC.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8daca315c6880cf44ad210c35bc04c6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SJH/SceneChanger.cs
+++ b/Assets/SJH/SceneChanger.cs
@@ -72,7 +72,7 @@ public class SceneChanger : MonoBehaviour
 		Player pc = player.GetComponent<Player>();
 		isChange = true;
 		pc.state = Define.PlayerState.SceneChange;
-		player.transform.position = new Vector3(exitPos.x, exitPos.y);
+		//player.transform.position = new Vector3(exitPos.x, exitPos.y);
 		pc.StopMoving();
 		pc.currentDirection = keyDirection;
 		pc.AnimChange();
@@ -83,20 +83,23 @@ public class SceneChanger : MonoBehaviour
 		{
 			if (asyncLoad.progress >= 0.9f)
 			{
-				//Debug.Log(gameObject.name);
-				player.transform.position = exitPos;
-				yield return new WaitForSeconds(0.1f);
-				asyncLoad.allowSceneActivation = true;
-
 				// 상태 초기화
+				yield return null;
+				player.transform.position = exitPos;
+				Debug.Log($"플레이어 이동 : {exitPos}");
 				isChange = false;
 				pc.state = Define.PlayerState.Field;
-				sceneCoroutine = null;
-				//Debug.Log("state init");
+				//yield return new WaitForSeconds(0.1f);
+				asyncLoad.allowSceneActivation = true;
 
 				break;  // 루프 탈출
 			}
 			yield return null;
+		}
+		if (sceneCoroutine != null)
+		{
+			StopCoroutine(sceneCoroutine);
+			sceneCoroutine = null;
 		}
 	}
 

--- a/Assets/SJH/SkillData.cs
+++ b/Assets/SJH/SkillData.cs
@@ -15,4 +15,32 @@ public struct SkillData
 		CurPP = curPP;
 		MaxPP = maxPP;
 	}
+
+	// pp 일정량 감소
+	public int DecreasePP(int value)
+	{
+		CurPP = Mathf.Max(0, CurPP - value);
+		return CurPP;
+	}
+
+	// pp 1 감소
+	public int DecreasePP()
+	{
+		CurPP = Mathf.Max(0, CurPP - 1);
+		return CurPP;
+	}
+
+	// pp 1 회복
+	public int IncreasePP(int value)
+	{
+		CurPP = Mathf.Min(MaxPP, CurPP + value);
+		return CurPP;
+	}
+
+	// 최대 PP로 변경 / 센터용
+	public int IncreaseMaxPP()
+	{
+		CurPP = MaxPP;
+		return CurPP;
+	}
 }

--- a/Assets/SJH/SkillData.cs
+++ b/Assets/SJH/SkillData.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public struct SkillData
+{
+	public string Name;
+	public int CurPP;
+	public int MaxPP;
+
+	public SkillData(string name, int curPP, int maxPP)
+	{
+		Name = name;
+		CurPP = curPP;
+		MaxPP = maxPP;
+	}
+}

--- a/Assets/SJH/SkillData.cs.meta
+++ b/Assets/SJH/SkillData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e47834eafc411c24880259dd36b8a8cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SproutTower1F.unity
+++ b/Assets/Scenes/SproutTower1F.unity
@@ -1899,6 +1899,63 @@ Transform:
   m_Children: []
   m_Father: {fileID: 49273815}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1304103773
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 349731098428950007, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_Name
+      value: CreatePlayer
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -18
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
 --- !u!1 &1385785031
 GameObject:
   m_ObjectHideFlags: 0
@@ -13549,7 +13606,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4894863921100760156, guid: 17e8a62a25801b14489427e8d7549ac7, type: 3}
       propertyPath: m_Name
-      value: Trainer6
+      value: Trainer5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -13666,3 +13723,4 @@ SceneRoots:
   - {fileID: 1601527870}
   - {fileID: 1093719656}
   - {fileID: 4859583772017814721}
+  - {fileID: 1304103773}

--- a/Assets/Scenes/SproutTower2F.unity
+++ b/Assets/Scenes/SproutTower2F.unity
@@ -12979,7 +12979,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2102706370458984131, guid: 44366e7209f2a66489443e2f0d53899b, type: 3}
       propertyPath: m_Name
-      value: Trainer5
+      value: Trainer6
       objectReference: {fileID: 0}
     - target: {fileID: 5596190004431903596, guid: 44366e7209f2a66489443e2f0d53899b, type: 3}
       propertyPath: m_LocalPosition.x


### PR DESCRIPTION
추후

# 📌 Pull Request
## 🔗 관련 이슈
<!--
❗ 상황에 따라 아래 중 하나로 작성하세요:
- PR 머지 시 이슈를 자동으로 닫으려면: resolves: #45
- 단순히 연동만 하고 싶다면: related to: #45
-->

(resolve 나 related to 중 하나 선택해서 작성)

---

## ✨ 작업 내용
- 작업한 내용, 변경 사항 간략히 설명
- 예 :
  - 트레이너 카드 메뉴 구현
    - 플레이어 프로필 정보를 보여주는 UI 구성 (이름, ID, 골드, 플레이 시간, 배지 현황)


## 🎥 스크린샷 / 영상 (선택)
<!--드래그 앤 드롭으로 GitHub에 업로드 가능-->

---

## 💬 리뷰 요청사항
- 리뷰어가 집중해서 봐줬으면 하는 코드/구조/로직이 있다면 작성
- 예:
  - 플레이 시간 갱신은 현재 `Coroutine`으로 처리하고 있는데, 더 나은 방식이 있다면 제안해주세요

---

## ✅ PR 체크리스트
- [ ] 이슈 번호에 `resolves:` 또는 `related to:`를 정확히 작성했는가?
- [ ] 불필요한 로그/주석/테스트 코드 제거했는가?
- [ ] 기능 테스트 및 정상 동작을 확인했는가?

---

## 📝 기타 참고사항 (선택)
- 논의 중이거나, 향후 개선이 필요한 부분이 있다면 작성
- 예:
  - 현재는 임시 플레이어 데이터를 사용 중이며, 이후 타이틀 씬과 연동 예정

