### PR TITLE
[Fix] 메뉴 UI - 포켓몬 컨디션 한글로 변환

### DIFF
--- a/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Element/UI_BattleSkillMenuController.cs
+++ b/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Element/UI_BattleSkillMenuController.cs
@@ -81,7 +81,8 @@ public class UI_BattleSkillMenuController : MonoBehaviour
 		int maxPP = skillData.MaxPP;
 
 	    skillPP.text = $"{curPP}/{maxPP}";
-	    skillType.text = skill.skillType.ToString();
+		//skillType.text = skill.skillType.ToString();
+		skillType.text = Define.GetKoreanSkillType[skill.skillType];
     }
     
     

--- a/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Element/UI_PokemonSlot.cs
+++ b/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Element/UI_PokemonSlot.cs
@@ -68,7 +68,8 @@ public class UI_PokemonSlot : MonoBehaviour
 		}
 		else
 		{
-			condition.text = pokemon.condition.ToString();
+			//condition.text = pokemon.condition.ToString();
+			condition.text = Define.GetKoreanState[pokemon.condition];
 			condition.gameObject.SetActive(true);
 		}
 

--- a/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Linked_Scripts/UI_PokemonInfo.cs
+++ b/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Linked_Scripts/UI_PokemonInfo.cs
@@ -115,8 +115,8 @@ public class UI_PokemonInfo : UI_Linked
 					//type1Text.text = pokemon.pokeType1.ToString();
 					//type2Text.text = pokemon.pokeType2.ToString();
 					statusText.text = Define.GetKoreanState[pokemon.condition]; // 한글로 변환
-					type1Text.text = Define.GetKoreanType[pokemon.pokeType1];
-					type2Text.text = Define.GetKoreanType[pokemon.pokeType2];
+					type1Text.text = Define.GetKoreanPokeType[pokemon.pokeType1];
+					type2Text.text = Define.GetKoreanPokeType[pokemon.pokeType2];
 					if(pokemon.pokeType2==Define.PokeType.None)
 						type2Text.gameObject.SetActive(false);
 					

--- a/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Linked_Scripts/UI_PokemonSkillInfo.cs
+++ b/Assets/LDH/LDH_Scripts/LDH_UI_Scripts/LDH_UI_Linked_Scripts/UI_PokemonSkillInfo.cs
@@ -130,7 +130,8 @@ public class UI_PokemonSkillInfo : UI_Linked
 
 		if (skill != null)
 		{
-			typeText.text = skill.type.ToString();
+			//typeText.text = skill.type.ToString();
+			typeText.text = Define.GetKoreanPokeType[skill.type];
 			damageText.text = skill.damage.ToString();
 			description.text = skill.description;
 		}
@@ -165,10 +166,16 @@ public class UI_PokemonSkillInfo : UI_Linked
 
 		if (hasSkill && data != null)
 		{
-			nameText = data.name;
+			SkillData skillData = party[partyIdx].skillDatas[index];
+			nameText = skillData.Name;
 			ppText = "PP";
-			curPP = $"{data.curPP}/";
-			maxPP = data.maxPP.ToString();
+			curPP = $"{skillData.CurPP}/";
+			maxPP = skillData.MaxPP.ToString();
+
+			//nameText = data.name;
+			//ppText = "PP";
+			//curPP = $"{data.curPP}/";
+			//maxPP = data.maxPP.ToString();
 		}
 		else if (hasSkill && data == null)
 		{

--- a/Assets/SJH/Define.cs
+++ b/Assets/SJH/Define.cs
@@ -95,7 +95,7 @@ public class Define
 		[StatusCondition.Faint] = "기절",
 		[StatusCondition.Flinch] = "풀죽음",
 	};
-	public static Dictionary<PokeType, string> GetKoreanType = new()
+	public static Dictionary<PokeType, string> GetKoreanPokeType = new()
 	{
 		[PokeType.None] = "없음",
 		[PokeType.Normal] = "노말",
@@ -115,6 +115,12 @@ public class Define
 		[PokeType.Dragon] = "드래곤",
 		[PokeType.Dark] = "악",
 		[PokeType.Steel] = "강철",
+	};
+	public static Dictionary<SkillType, string> GetKoreanSkillType = new()
+	{
+		[SkillType.Physical] = "물리",
+		[SkillType.Special] = "특수",
+		[SkillType.Status] = "변화",
 	};
 
 


### PR DESCRIPTION
# 📌 Pull Request
## 🔗 관련 이슈
<!--
❗ 상황에 따라 아래 중 하나로 작성하세요:
- PR 머지 시 이슈를 자동으로 닫으려면: resolves: #45
- 단순히 연동만 하고 싶다면: related to: #45
-->

(resolve 나 related to 중 하나 선택해서 작성)

---

## ✨ 작업 내용
- 작업한 내용, 변경 사항 간략히 설명
- 예 :
  - 트레이너 카드 메뉴 구현
    - 플레이어 프로필 정보를 보여주는 UI 구성 (이름, ID, 골드, 플레이 시간, 배지 현황)


## 🎥 스크린샷 / 영상 (선택)
<!--드래그 앤 드롭으로 GitHub에 업로드 가능-->

---

## 💬 리뷰 요청사항
- 리뷰어가 집중해서 봐줬으면 하는 코드/구조/로직이 있다면 작성
- 예:
  - 플레이 시간 갱신은 현재 `Coroutine`으로 처리하고 있는데, 더 나은 방식이 있다면 제안해주세요

---

## ✅ PR 체크리스트
- [ ] 이슈 번호에 `resolves:` 또는 `related to:`를 정확히 작성했는가?
- [ ] 불필요한 로그/주석/테스트 코드 제거했는가?
- [ ] 기능 테스트 및 정상 동작을 확인했는가?

---

## 📝 기타 참고사항 (선택)
- 논의 중이거나, 향후 개선이 필요한 부분이 있다면 작성
- 예:
  - 현재는 임시 플레이어 데이터를 사용 중이며, 이후 타이틀 씬과 연동 예정

