### PR TITLE
[Feat] 포켓몬 할아버지 이벤트 추가

### DIFF
--- a/Assets/MSK/MSKScripts/NpcMover.cs
+++ b/Assets/MSK/MSKScripts/NpcMover.cs
@@ -44,6 +44,7 @@ public class NpcMover : MonoBehaviour
 	[SerializeField] public bool isNPCMoveCheck;
 	//	회전
 	[SerializeField] public bool isNPCTurnCheck;
+	public event Action MoveFin;
 	
 	private void Awake()
 	{
@@ -218,6 +219,7 @@ public class NpcMover : MonoBehaviour
 			{
 				isNPCMoveCheck = false;
 				anim.SetBool("npcMoving", false);
+				MoveFin?.Invoke();
 			}
 
 			npcMoveCoroutione = null;
@@ -283,6 +285,7 @@ public class NpcMover : MonoBehaviour
 		anim.SetFloat("y", currentDirection.y);
 
 		Manager.Dialog.npcState = NpcState.Idle;
+		MoveFin?.Invoke();
 	}
 
 	private bool IsWalkAble(Vector2 currentDirection)

--- a/Assets/Prefabs/NPC/NPC57.prefab
+++ b/Assets/Prefabs/NPC/NPC57.prefab
@@ -165,8 +165,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c9198d2aa9d2ef04cb86cdd070345c2d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  exitPos: {x: 0, y: 0}
   destinationPoints: []
   moveDuration: 0.3
   rotateInterval: 2
-  npcTurn: 0
-  dir: {x: 0, y: 0}
+  moveSpeed: 0
+  npcMoving: 0
+  moveIndex: 0
+  currentDirection: {x: 0, y: 0}
+  isNpcIntervalCheak: 0
+  isPaused: 0
+  isNPCMoveCheck: 0
+  isNPCTurnCheck: 0

--- a/Assets/SJH/CreatePlayer.prefab
+++ b/Assets/SJH/CreatePlayer.prefab
@@ -26,7 +26,7 @@ Transform:
   m_GameObject: {fileID: 349731098428950007}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -256, y: 134, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/SJH/EventManager.cs
+++ b/Assets/SJH/EventManager.cs
@@ -14,29 +14,30 @@ public class EventManager : Singleton<EventManager>
 	// 이벤트 트리거들
 	[SerializeField] public bool pokegearEvent;         // 2층에서 1층가면 포켓기어 설명 + 공박사한테 가라는 이벤트
 	[SerializeField] public bool berryHouseEvent;          // 30번도로 나무열매집 엔피시 말걸면 나무열매 주는 이벤트
+
+	[SerializeField] public bool questEvent;                // 포켓몬 할아버지 집 가라는 이벤트
+	[SerializeField] public bool starterEvent;             // 공박사에게 스타팅 포켓몬 받는 이벤트
+	[SerializeField] public bool beforeQuestEvent;			//	박사 연구소 첫 입장 시 강제 움직임 이벤트
+	[SerializeField] public bool starterSubEvent;           // 스타팅 받고 나갈 때 조수가 상처약 주는 이벤트
+	[SerializeField] public bool pokemonHouseEvent;        // 포켓몬 할아버지집 들어가면 강제 이벤트 (대충 설명)
+
+
 	[SerializeField] public bool townExitEvent;             // 연두마을 나갈 때 포켓몬 없으면 못나가게하는 이벤트
 
 
-
-
-	[SerializeField] public bool rivalEvent1;               // 연두마을 연구소 옆에서 라이벌한테 말걸면 차이는 이벤트
-	[SerializeField] public bool eggEvent;                  // 체육관 승리 후 체육관 나가면 강제 이벤트 (전화) 센터가면 포켓몬알줌 끝
+	[SerializeField] public bool rivalEvent1;              // 연두마을 연구소 옆에서 라이벌한테 말걸면 차이는 이벤트
+	[SerializeField] public bool eggEvent;                 // 체육관 승리 후 체육관 나가면 강제 이벤트 (전화) 센터가면 포켓몬알줌 끝
 	[SerializeField] public bool gymEvent;                 // 체육관 이벤트 (승리시)
-	//	[SerializeField] public bool teachEvent;               // 무궁시티 체육관 왼쪽에 말걸면 학교로 데려가서 설명해주는 이벤트
+	//	[SerializeField] public bool teachEvent;           // 무궁시티 체육관 왼쪽에 말걸면 학교로 데려가서 설명해주는 이벤트
 	[SerializeField] public bool cherrygroveCityInfoEvent; // 무궁시티 마을 입구 할아버지 말걸면 마을 소개해주는 이벤트
 	[SerializeField] public bool sproutTowerEvent;         // 모다피탑 3층에서 라이벌과 스님이 얘기하는 이벤트
 
 
 
-	[SerializeField] public bool beforeQuestEvent;
-	[SerializeField] public bool questEvent;                // 포켓몬 할아버지 집 가라는 이벤트
 	//questEvent True일 경우 방생
-	[SerializeField] public bool starterEvent;             // 공박사에게 스타팅 포켓몬 받는 이벤트
 	//questEvent True starterEvent true 일 경우 방생
-	[SerializeField] public bool starterSubEvent;           // 스타팅 받고 나갈 때 조수가 상처약 주는 이벤트
 	[SerializeField] public bool adventureEvent;           // 연구소 들어가면 모험 떠나라는 이벤트
 
-	[SerializeField] public bool pokemonHouseEvent;        // 포켓몬 할아버지집 들어가면 강제 이벤트 (대충 설명)
 	[SerializeField] public bool backNewBarkTownEvent;     // pokemonHouseEvent true일 떄 포켓몬 할아버지집 나가면 강제 이벤트 (대충 마을로오라는)
 	[SerializeField] public bool rivalEvent2;              // 연두마을 가는길에 라이벌 배틀 이벤트
 

--- a/Assets/SJH/EventScripts/PokemonHouseEvent.cs
+++ b/Assets/SJH/EventScripts/PokemonHouseEvent.cs
@@ -4,90 +4,157 @@ using UnityEngine;
 
 public class PokemonHouseEvent : PokeEvent
 {
+	[Header("대화 관련 설정")]
+	[SerializeField] private Dialog dialog;
+	[SerializeField] private GameObject npc;
+	[SerializeField] private bool isMove;
+	NpcMover npcMover;
+	private Vector2 originalNpcPosition;
+	private void ReturnNpcDialogue()
+	{
+		Manager.Dialog.CloseDialog -= ReturnNpcDialogue;
+		StartCoroutine(ReturnNpcPosition());
+	}
+
+	private void NextNpcDialogue()
+	{
+		Manager.Dialog.CloseDialog -= NextNpcDialogue;
+		StartCoroutine(NextNpcDialog());
+	}
+	private void LastNpcDialogue()
+	{
+		Manager.Dialog.CloseDialog -= LastNpcDialogue;
+		StartCoroutine(LastNpcDialog());
+	}
+
+	private void OnCollisionEnter2D(Collision2D collision)
+	{
+		if (collision.gameObject.CompareTag("Player"))
+		{
+			if (Manager.Event.pokemonHouseEvent)
+				return;
+
+
+			Manager.Game.Player.PlayerMove(new Vector2(1, 1));
+			Manager.Game.Player.AnimChange(Vector2.up);
+			Manager.Game.Player.StopMoving();
+
+			NpcMover npcMover = npc.GetComponent<NpcMover>();
+			originalNpcPosition = npc.transform.position;
+			Debug.Log("플레이어 닿음");
+
+			if (!isMove)
+			{
+				isMove = true;
+				npcMover.isNPCMoveCheck = true;
+				StartCoroutine(TriggerDialogue());
+			}
+			Manager.Event.pokemonHouseEvent = true;
+		}
+	}
+
+
 	public override void OnPokeEvent(GameObject player)
 	{
 
 		/*
-이야이야
-네가 player.name군이로군
-공박사로부터 
-연락이 있어서 기다리고 있었단다
 
-플레이어 할아버지에게  이동
-
-이것이 공박사에게
-조사를 의뢰하고싶은 것이란다!
-player.name은
-포켓몬 할아버지로부터
-이상한 알을 받았다.
-이상한 알을
-중요한 포켓에 넣었다
-포켓몬을 맡아 기르고 있는
-부부가 있는데
-거기서 얻은 것이란다
-혹시 그렇다면.... 라고 생각해서
-공박사에게 메일을 보냈단다
-포켓몬 진화의 연구라면 
-공박사가 최고니까
-여하튼 이 오박사도 
-인정하는 정도니까
-
-오박사 플레이어에게 다가옴
-
-내 상상이 맞았는가...
-공박사라면 알고있을 터
 
 (npc 옆 노란머리 말걸어옴)
-오박사"호오!
-네가 player.name군인가!
-나는 오박사
-포켓몬 연구를 하고있단다
-오랜 친구인 
-포켓몬 할아버지를 방문 해보니까
-공박사가 있는 곳으로부터
-심부름군이 온다고 들어서
-기다리고 있었단다!
-호오!
-진귀한 포켓몬을 가지고 있구나
-게다가.....
-흐음 역시!
-공박사가 포켓몬을 줘서 
-너에게 심부름을 부탁한 이유를
-잘 알겠구나
-나와 공박사같은 
-연구가에게 있어서 포켓몬은
-소중한 친구이기 때문이란다
-너라면 포켓몬을 소중하게 
-키울 것 이라 생각한단다
-....그렇구나!
-너에게 기대를 걸고 나도
-한가지 부탁을 할까!
-실은......
-이것이 포켓몬 도감이란다
-발견한 포켓몬의 데이터가
-자동적으로 기록되어져
-페이지가 늘어간다고 하는
-하이테크 도감이란다
-(포켓몬 도감을 획득하였습니다)
-많은 포켓몬과 만나서
-이 도감을 완전하게
-만들어 주었으면 좋겠구나
-이런!
-오랫동안 시간을 끌었구나
-이제부터 김빛시티에 가서 늘
-그렇듯이 라디오 방송을
-녹음하지 않으면 안 되겠구나
-그럼 player.name군
-잘 부탁한다
+
 (오박사)
 
 npc할배박사
-공박사가 계신곳에 돌아갈 작정인가?
-약간 포켓몬을 쉬게 하는것이 좋겠지
-
 포켓몬 치료 이벤트
 
-그럼 잘 부탁한다!
 		 */
 	}
+
+	private IEnumerator LastNpcDialog()
+	{
+		Manager.Game.Player.AnimChange(Vector2.up);
+		dialog = new Dialog(new List<string>
+		{
+				"공박사가 계신곳에 돌아갈 작정인가?",
+				"약간 포켓몬을 쉬게 하는것이 좋겠지",
+				"그럼 잘 부탁한다!"
+		});
+		Manager.Dialog.StartDialogue(dialog);
+
+		while (Manager.Dialog.isTyping)
+		{
+			yield return null;
+		}
+
+	}
+	private IEnumerator TriggerDialogue()
+	{
+		Manager.Dialog.StartDialogue(dialog);
+		Manager.Dialog.CloseDialog += NextNpcDialogue;
+
+		while (Manager.Dialog.isTyping)
+		{
+			yield return null;
+		}
+		isMove = false;
+	}
+	private IEnumerator NextNpcDialog()
+	{
+		Manager.Game.Player.AnimChange(Vector2.right);
+		Manager.Game.Player.StopMoving();
+		dialog = new Dialog(new List<string>
+			{
+				"호오! 네가 골드군인가!",
+				"나는 오박사, 포켓몬 연구를 하고있단다",
+				"오랜 친구인 포켓몬 할아버지를 방문 해보니까",
+				"공박사가 있는 곳으로부터",
+				"심부름군이 온다고 들어서",
+				"기다리고 있었단다!",
+				"호오! 진귀한 포켓몬을 가지고 있구나",
+				"게다가..... 흐음 역시!",
+				"공박사가 포켓몬을 줘서 ",
+				"너에게 심부름을 부탁한 이유를 잘 알겠구나",
+				"나와 공박사같은 연구가에게 있어서",
+				"포켓몬은 소중한 친구이기 때문이란다",
+				"너라면 포켓몬을 소중하게 키울 것 이라 생각한단다",
+				"....그렇구나!",
+				"너에게 기대를 걸고 나도 한가지 부탁을 할까!",
+				"실은...... 이것이 포켓몬 도감이란다",
+				"발견한 포켓몬의 데이터가 자동적으로 기록되어져",
+				"페이지가 늘어간다고 하는 하이테크 도감이란다",
+				"많은 포켓몬과 만나서 이 도감을 완전하게 만들어 주었으면 좋겠구나",
+				"이런! 오랫동안 시간을 끌었구나",
+				"이제부터 금빛시티에 가서 늘 그렇듯이 라디오 방송을 녹음하지 않으면 안 되겠구나",
+				"그럼 골드군, 잘 부탁한다"
+			});
+
+		Manager.Dialog.StartDialogue(dialog);
+		Manager.Dialog.CloseDialog += ReturnNpcDialogue;
+		while (Manager.Dialog.isTyping)
+		{
+			yield return null;
+		}
+	}
+
+	private IEnumerator ReturnNpcPosition()
+	{
+		NpcMover npcMover = npc.GetComponent<NpcMover>();
+
+		if (npcMover.destinationPoints.Count == 0 || (Vector2)npc.transform.position != originalNpcPosition)
+		{
+			npcMover.destinationPoints = new List<Vector2> { new Vector2(2, -20), new Vector2(0, -20) };
+			npcMover.moveIndex = 0;
+			npcMover.isNPCMoveCheck = true;
+		}
+
+		npcMover.StopMoving();
+		npcMover.MoveFin += LastNpcDialogue;
+		while (npcMover.isNPCMoveCheck)
+		{
+			yield return null;
+		}
+
+		npc.SetActive(false);
+	}
 }
+

--- a/Assets/SJH/EventScripts/StarterSubEvent.cs
+++ b/Assets/SJH/EventScripts/StarterSubEvent.cs
@@ -10,11 +10,13 @@ public class StarterSubEvent : PokeEvent
 	[SerializeField] private bool isMove;
 	NpcMover npcMover;
 	private Vector2 originalNpcPosition;
+
 	private void ReturnNpcDialogue()
 	{
 		Manager.Dialog.CloseDialog -= ReturnNpcDialogue;
 		StartCoroutine(ReturnNpcPosition());
 	}
+
 	private void OnCollisionEnter2D(Collision2D collision)
 	{
 		if (collision.gameObject.CompareTag("Player") && Manager.Event.starterEvent)
@@ -35,6 +37,7 @@ public class StarterSubEvent : PokeEvent
 
 			npcMover.AnimChange(Vector2.right);
 			originalNpcPosition = npc.transform.position;
+			Manager.Game.Player.StopMoving();
 			Debug.Log("플레이어 닿음");
 
 			if (!isMove)

--- a/Assets/Scenes/PokemonHouse.unity
+++ b/Assets/Scenes/PokemonHouse.unity
@@ -349,7 +349,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1093879144}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &262384818
@@ -945,6 +946,119 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1787612750}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1093879143
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1093879144}
+  - component: {fileID: 1093879146}
+  - component: {fileID: 1093879145}
+  m_Layer: 0
+  m_Name: PokeGearEvent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1093879144
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1093879143}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -2, y: -20, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 217936586}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1093879145
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1093879143}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 161ddadd9134a4c4f90ca8bf52dbce45, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dialog:
+    lines:
+    - "\uC774\uC57C\uC774\uC57C, \uB124\uAC00 \uACE8\uB4DC\uAD70\uC774\uB85C\uAD70"
+    - "\uACF5\uBC15\uC0AC\uB85C\uBD80\uD130  \uC5F0\uB77D\uC774 \uC788\uC5B4\uC11C
+      \uAE30\uB2E4\uB9AC\uACE0 \uC788\uC5C8\uB2E8\uB2E4"
+    - "\uC774\uAC83\uC774 \uACF5\uBC15\uC0AC\uC5D0\uAC8C \uC870\uC0AC\uB97C \uC758\uB8B0\uD558\uACE0\uC2F6\uC740
+      \uAC83\uC774\uB780\uB2E4!"
+    - "\uACE8\uB4DC\uB294 \uD3EC\uCF13\uBAAC \uD560\uC544\uBC84\uC9C0\uB85C\uBD80\uD130
+      \uC774\uC0C1\uD55C \uC54C\uC744 \uBC1B\uC558\uB2E4."
+    - "\uC774\uC0C1\uD55C \uC54C\uC744 \uC911\uC694\uD55C \uD3EC\uCF13\uC5D0 \uB123\uC5C8\uB2E4"
+    - "\uD3EC\uCF13\uBAAC\uC744 \uB9E1\uC544 \uAE30\uB974\uACE0 \uC788\uB294"
+    - "\uBD80\uBD80\uAC00 \uC788\uB294\uB370 \uAC70\uAE30\uC11C \uC5BB\uC740 \uAC83\uC774\uB780\uB2E4"
+    - "\uD639\uC2DC \uADF8\uB807\uB2E4\uBA74.... \uB77C\uACE0 \uC0DD\uAC01\uD574\uC11C
+      \uACF5\uBC15\uC0AC\uC5D0\uAC8C \uBA54\uC77C\uC744 \uBCF4\uB0C8\uB2E8\uB2E4"
+    - "\uD3EC\uCF13\uBAAC \uC9C4\uD654\uC758 \uC5F0\uAD6C\uB77C\uBA74  \uACF5\uBC15\uC0AC\uAC00
+      \uCD5C\uACE0\uB2C8\uAE4C"
+    - "\uC5EC\uD558\uD2BC \uC774 \uC624\uBC15\uC0AC\uB3C4  \uC778\uC815\uD558\uB294
+      \uC815\uB3C4\uB2C8\uAE4C"
+    - "\uB0B4 \uC0C1\uC0C1\uC774 \uB9DE\uC558\uB294\uAC00... \uACF5\uBC15\uC0AC\uB77C\uBA74
+      \uC54C\uACE0\uC788\uC744 \uD130"
+  npc1: {fileID: 8645870667295629459}
+  npc2: {fileID: 2061531879}
+  isMove: 0
+--- !u!61 &1093879146
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1093879143}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.8, y: 1.8}
+  m_EdgeRadius: 0
 --- !u!1 &1220975170
 GameObject:
   m_ObjectHideFlags: 0
@@ -4157,6 +4271,11 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!1 &2061531879 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2994874419291185717, guid: 5f0c44390446d8646bf6b35ba7279a44, type: 3}
+  m_PrefabInstance: {fileID: 3381091287388753785}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2067620418
 GameObject:
   m_ObjectHideFlags: 0
@@ -4888,6 +5007,34 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -4359326466646589956, guid: c4c7ad78891f7f04eb989b2f9a541357, type: 3}
+      propertyPath: exitPos.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -4359326466646589956, guid: c4c7ad78891f7f04eb989b2f9a541357, type: 3}
+      propertyPath: exitPos.y
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: -4359326466646589956, guid: c4c7ad78891f7f04eb989b2f9a541357, type: 3}
+      propertyPath: destinationPoints.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -4359326466646589956, guid: c4c7ad78891f7f04eb989b2f9a541357, type: 3}
+      propertyPath: destinationPoints.Array.data[0].x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: -4359326466646589956, guid: c4c7ad78891f7f04eb989b2f9a541357, type: 3}
+      propertyPath: destinationPoints.Array.data[0].y
+      value: -18
+      objectReference: {fileID: 0}
+    - target: {fileID: -4359326466646589956, guid: c4c7ad78891f7f04eb989b2f9a541357, type: 3}
+      propertyPath: destinationPoints.Array.data[1].x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -4359326466646589956, guid: c4c7ad78891f7f04eb989b2f9a541357, type: 3}
+      propertyPath: destinationPoints.Array.data[1].y
+      value: -18
+      objectReference: {fileID: 0}
     - target: {fileID: 3974022131882726100, guid: c4c7ad78891f7f04eb989b2f9a541357, type: 3}
       propertyPath: m_LocalPosition.x
       value: 8
@@ -4937,6 +5084,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c4c7ad78891f7f04eb989b2f9a541357, type: 3}
+--- !u!1 &8645870667295629459 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6125383472956823835, guid: c4c7ad78891f7f04eb989b2f9a541357, type: 3}
+  m_PrefabInstance: {fileID: 8645870667295629458}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8760697914299916543
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/ProfessorLab.unity
+++ b/Assets/Scenes/ProfessorLab.unity
@@ -886,6 +886,23 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 5413551415809611818, guid: 50fa6eaa66ae7e84ea9ae4aa2168930e, type: 3}
   m_PrefabInstance: {fileID: 7193187939093470725}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &476075135
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476075129}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 02ef73625943f2d498f113e21dd28dd7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dialog:
+    lines:
+    - "\uC870\uC2EC\uD788 \uB2E4\uB140\uC624\uC138\uC694"
+  pokeEvent: {fileID: 0}
+  anim: {fileID: 0}
 --- !u!1001 &506105074
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1788,6 +1805,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+--- !u!1 &1577185410 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8022576220340951505, guid: bc7ab25fac83a5646af85d080868a539, type: 3}
+  m_PrefabInstance: {fileID: 1403022556033379903}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1597317208
 GameObject:
   m_ObjectHideFlags: 0
@@ -6180,6 +6202,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e956d32db2109dd49afd0a932205adb8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  dialog:
+    lines:
+    - "\uACE8\uB4DC\uAD70!"
+    - "\uC2EC\uBD80\uB984\uC744 \uD574\uC8FC\uB294 \uADF8\uB300\uC5D0\uAC8C \uC774\uAC83\uC744
+      \uC904\uAED8\uC694!"
+    - "\uACE8\uB4DC\uB294 \uC0C1\uCC98\uC57D\uC744 \uC5BB\uC5C8\uB2E4!"
+    - "\uACE8\uB4DC\uB294 \uC0C1\uCC98\uC57D\uC744 \uB3C4\uAD6C\uD3EC\uCF13\uC5D0
+      \uB123\uC5C8\uB2E4"
+    - "\uB458\uBC16\uC5D0 \uC5C6\uC73C\uB2C8\uAE4C \uC57D\uAC04\uC758 \uC77C\uB85C\uB3C4
+      \uB2F9\uD669\uC2A4\uB7FD\uB2E4...."
+    - "\uC544\u3161\u3161 \uBC14\uBE60\uC694"
+  npc: {fileID: 1577185410}
+  isMove: 0
 --- !u!61 &2101887713
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -6924,7 +6959,10 @@ PrefabInstance:
     - {fileID: 0}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5413551415809611818, guid: 50fa6eaa66ae7e84ea9ae4aa2168930e, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 476075135}
   m_SourcePrefab: {fileID: 100100000, guid: 50fa6eaa66ae7e84ea9ae4aa2168930e, type: 3}
 --- !u!1001 &8059626114563416137
 PrefabInstance:

--- a/Assets/Scenes/Route30.unity
+++ b/Assets/Scenes/Route30.unity
@@ -2183,6 +2183,158 @@ Transform:
   - {fileID: 1608137885}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &279278459
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 279278460}
+  - component: {fileID: 279278463}
+  - component: {fileID: 279278462}
+  - component: {fileID: 279278461}
+  m_Layer: 0
+  m_Name: "\uBE68\uAC04\uAF2C\uB81B"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &279278460
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 279278459}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -15, y: 27.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 575754981}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &279278461
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 279278459}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 52d8cefef5e354f48ac11721291dadb7, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!212 &279278462
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 279278459}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -321165417, guid: eccb57e7aa4ee1d48b93058b9e8dca0a, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &279278463
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 279278459}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2, y: 2}
+  m_EdgeRadius: 0
 --- !u!1001 &284033111
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2307,6 +2459,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8274744671361420350, guid: 25f62136e11fba743af3a5bd97df17ef, type: 3}
   m_PrefabInstance: {fileID: 295388591}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &299072547
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 349731098428950007, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_Name
+      value: CreatePlayer
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -166
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2102166460230956873, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a760862bc9291ab4ca56ba18e20205e2, type: 3}
 --- !u!1001 &302887799
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2629,6 +2838,136 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6270959539984545281, guid: 3d6c7bec28fe11040a6f42b36d3adb6a, type: 3}
   m_PrefabInstance: {fileID: 325859271}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &331098387
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 331098388}
+  - component: {fileID: 331098390}
+  - component: {fileID: 331098389}
+  m_Layer: 0
+  m_Name: "\uBE68\uAC04\uAF2C\uB81B\uD2B8\uB808\uC774\uB108"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &331098388
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 331098387}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -15, y: 29.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 575754981}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &331098389
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 331098387}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 253629350, guid: 36c8bcf4a5544bf4292060930335b65a, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &331098390
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 331098387}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1001 &332715773
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3575,6 +3914,199 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8274744671361420350, guid: 25f62136e11fba743af3a5bd97df17ef, type: 3}
   m_PrefabInstance: {fileID: 493304057}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &498437413
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 498437414}
+  - component: {fileID: 498437419}
+  - component: {fileID: 498437418}
+  - component: {fileID: 498437417}
+  - component: {fileID: 498437416}
+  - component: {fileID: 498437415}
+  m_Layer: 0
+  m_Name: "\uD30C\uB780\uAF2C\uB81B\uD2B8\uB808\uC774\uB108"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &498437414
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 498437413}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -15, y: 23.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 575754981}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &498437415
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 498437413}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e19b4bc8e14ecc846b8824712aa2ef30, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dialog:
+    lines:
+    - "\uAC00\uAC70\uB77C! \uAF2C\uB7AB"
+    - "\uBAB8\uD1B5\uBC15\uCE58\uAE30!"
+    - "\uBB50\uC57C?"
+    - "\uC911\uC694\uD55C \uC2B9\uBD80\uB97C \uD558\uACE0\uC788\uC5B4!"
+    - "\uC800\uB9AC \uAC00\uB780\uB9D0\uC57C!"
+  npc: {fileID: 498437413}
+--- !u!114 &498437416
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 498437413}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 02ef73625943f2d498f113e21dd28dd7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dialog:
+    lines: []
+  pokeEvent: {fileID: 0}
+  anim: {fileID: 0}
+--- !u!114 &498437417
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 498437413}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c9198d2aa9d2ef04cb86cdd070345c2d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  exitPos: {x: 0, y: 0}
+  destinationPoints: []
+  moveDuration: 0.3
+  rotateInterval: 2
+  moveSpeed: 0
+  npcMoving: 0
+  moveIndex: 0
+  currentDirection: {x: 0, y: 0}
+  isNpcIntervalCheak: 0
+  isPaused: 0
+  isNPCMoveCheck: 0
+  isNPCTurnCheck: 0
+--- !u!212 &498437418
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 498437413}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 100914187, guid: 36c8bcf4a5544bf4292060930335b65a, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &498437419
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 498437413}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &513726590
 GameObject:
   m_ObjectHideFlags: 0
@@ -4035,6 +4567,108 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6800156735006346029, guid: b6b1841ccc781c74684fccc635b4e818, type: 3}
   m_PrefabInstance: {fileID: 574935039}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &575754980
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 575754981}
+  - component: {fileID: 575754983}
+  - component: {fileID: 575754982}
+  m_Layer: 0
+  m_Name: RoadblockEvent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &575754981
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 575754980}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -170, y: 100, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 331098388}
+  - {fileID: 279278460}
+  - {fileID: 1916333363}
+  - {fileID: 498437414}
+  m_Father: {fileID: 1586213439}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &575754982
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 575754980}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72136f84c64fed24db3d9a0cd1ae48c5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dialog:
+    lines:
+    - "\uC5EC \uC5EC\uBCF4\uC138\uC694 \uACE8\uB4DC\uAD70?"
+    - "\uD06C \uD070\uC77C\uB0AC\uAD6C\uB098!! \uC5D0- \uADF8\uB7EC\uB2C8\uAE4C \uBB50\uAC00
+      \uBB50\uC600\uB294\uC9C0......"
+    - "\uC5B4\uB5A1\uD558\uC9C0...... \uC544\uBB34\uD2BC \uD070\uC77C\uC774\uB780\uB2E4! "
+    - "\uC9C0\uAE08 \uBC14\uB85C \uB3CC\uC544\uC624\uB108\uB77C! "
+    - "\uC091......!"
+--- !u!61 &575754983
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 575754980}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 4, y: 2}
+  m_EdgeRadius: 0
 --- !u!1 &593339766
 GameObject:
   m_ObjectHideFlags: 0
@@ -6846,7 +7480,7 @@ SpriteRenderer:
   m_Size: {x: 2, y: 2}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
+  m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!61 &1162375364
@@ -15956,6 +16590,38 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6270959539984545281, guid: 3d6c7bec28fe11040a6f42b36d3adb6a, type: 3}
   m_PrefabInstance: {fileID: 1580398565}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1586213438
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1586213439}
+  m_Layer: 0
+  m_Name: EventTrigger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1586213439
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1586213438}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 575754981}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1590172004
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17688,6 +18354,158 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8274744671361420350, guid: 25f62136e11fba743af3a5bd97df17ef, type: 3}
   m_PrefabInstance: {fileID: 1892092004}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1916333362
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1916333363}
+  - component: {fileID: 1916333366}
+  - component: {fileID: 1916333365}
+  - component: {fileID: 1916333364}
+  m_Layer: 0
+  m_Name: "\uD30C\uB780\uAF2C\uB81B"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1916333363
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1916333362}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -15, y: 25.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 575754981}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &1916333364
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1916333362}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: ed6d36eb471417449bf80a03eff8c624, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!212 &1916333365
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1916333362}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -1236657379, guid: eccb57e7aa4ee1d48b93058b9e8dca0a, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &1916333366
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1916333362}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2, y: 2}
+  m_EdgeRadius: 0
 --- !u!1001 &1924475881
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -43782,7 +44600,7 @@ SpriteRenderer:
   m_Size: {x: 2, y: 2}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
+  m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!61 &2123923794
@@ -46145,3 +46963,5 @@ SceneRoots:
   - {fileID: 2233304839234478174}
   - {fileID: 1199773033307244179}
   - {fileID: 1227488042}
+  - {fileID: 299072547}
+  - {fileID: 1586213439}


### PR DESCRIPTION
# 📌 Pull Request
## 🔗 관련 이슈
<!--
❗ 상황에 따라 아래 중 하나로 작성하세요:
- PR 머지 시 이슈를 자동으로 닫으려면: resolves: #45
- 단순히 연동만 하고 싶다면: related to: #45
-->

(resolve 나 related to 중 하나 선택해서 작성)

---

## ✨ 작업 내용
- 작업한 내용, 변경 사항 간략히 설명
- 예 :
  - 트레이너 카드 메뉴 구현
    - 플레이어 프로필 정보를 보여주는 UI 구성 (이름, ID, 골드, 플레이 시간, 배지 현황)


## 🎥 스크린샷 / 영상 (선택)
<!--드래그 앤 드롭으로 GitHub에 업로드 가능-->

---

## 💬 리뷰 요청사항
- 리뷰어가 집중해서 봐줬으면 하는 코드/구조/로직이 있다면 작성
- 예:
  - 플레이 시간 갱신은 현재 `Coroutine`으로 처리하고 있는데, 더 나은 방식이 있다면 제안해주세요

---

## ✅ PR 체크리스트
- [ ] 이슈 번호에 `resolves:` 또는 `related to:`를 정확히 작성했는가?
- [ ] 불필요한 로그/주석/테스트 코드 제거했는가?
- [ ] 기능 테스트 및 정상 동작을 확인했는가?

---

## 📝 기타 참고사항 (선택)
- 논의 중이거나, 향후 개선이 필요한 부분이 있다면 작성
- 예:
  - 현재는 임시 플레이어 데이터를 사용 중이며, 이후 타이틀 씬과 연동 예정

